### PR TITLE
existential wrappers for the static vectors and matrices

### DIFF
--- a/packages/base/hmatrix.cabal
+++ b/packages/base/hmatrix.cabal
@@ -56,7 +56,8 @@ library
                         storable-complex,
                         semigroups,
                         finite-typelits,
-                        vector >= 0.11
+                        vector >= 0.11,
+                        mtl
 
     hs-source-dirs:     src
 


### PR DESCRIPTION
As the continuation-passing style of the existential type is hard to pass around, its wrapper is introduced.

For example, we can't make a list of the CPS of the existential type as below
![2022-03-11_15-41](https://user-images.githubusercontent.com/88674591/157816072-028516c1-1c41-45de-9257-c5a787521c3c.png)

However, the existential type is wrapped with a constructor, this is possible to make a list.
```haskell
data SomeTest = forall z. SomeTest (Test z)

x1' :: SomeTest
x1' = SomeTest (Test 10.0)

x2' :: SomeTest
x2' = SomeTest (Test 10.0)

xs' :: [SomeTest]
xs' = [x1', x2']

```