### PR TITLE
(|||) for complex matrix corrected to use proper conjugate

### DIFF
--- a/packages/base/src/Internal/Static/Complex.hs
+++ b/packages/base/src/Internal/Static/Complex.hs
@@ -143,7 +143,7 @@ a === b = mkM (extract a LA.=== extract b)
 
 infixl 3 |||
 (|||) :: (KnownNat r, KnownNat c1, KnownNat c2, KnownNat (c1+c2)) => M r c1 -> M r c2 -> M r (c1+c2)
-a ||| b = tr' (tr' a === tr' b)
+a ||| b = mkM (extract a LA.||| extract b)
 
 
 type Sq n  = M n n

--- a/packages/base/src/Internal/Static/Complex.hs
+++ b/packages/base/src/Internal/Static/Complex.hs
@@ -143,7 +143,7 @@ a === b = mkM (extract a LA.=== extract b)
 
 infixl 3 |||
 (|||) :: (KnownNat r, KnownNat c1, KnownNat c2, KnownNat (c1+c2)) => M r c1 -> M r c2 -> M r (c1+c2)
-a ||| b = tr (tr a === tr b)
+a ||| b = tr' (tr' a === tr' b)
 
 
 type Sq n  = M n n


### PR DESCRIPTION
I've wasted many hours due to this bugs ... Complex conjugated transposition was used for the juxtaposition where the normal transposition has to be used.

```sh
ghci> x = vector [1:+1,2,3] :: C 3
ghci> x
(vector [1.0 :+ 1.0,2.0 :+ 0.0,3.0 :+ 0.0] :: C 3)
ghci> -x
(vector [(-1.0) :+ (-1.0),(-2.0) :+ (-0.0),(-3.0) :+ (-0.0)] :: C 3)
ghci> y = diag x
ghci> y
(diag 0.0 :+ 0.0 [1.0 :+ 1.0,2.0 :+ 0.0,3.0 :+ 0.0] :: M 3 3)
ghci> (-y)
(diag 0.0 :+ (-0.0) [(-1.0) :+ (-1.0),(-2.0) :+ (-0.0),(-3.0) :+ (-0.0)] :: M 3 3)
ghci> (-y) ||| y
(matrix
 [ (-1.0) :+ 1.0,    0.0 :+ 0.0,    0.0 :+ 0.0, 1.0 :+ (-1.0), 0.0 :+ (-0.0), 0.0 :+ (-0.0)
 ,    0.0 :+ 0.0, (-2.0) :+ 0.0,    0.0 :+ 0.0, 0.0 :+ (-0.0), 2.0 :+ (-0.0), 0.0 :+ (-0.0)
 ,    0.0 :+ 0.0,    0.0 :+ 0.0, (-3.0) :+ 0.0, 0.0 :+ (-0.0), 0.0 :+ (-0.0), 3.0 :+ (-0.0) ] :: M 3 6)
```